### PR TITLE
Dev dte 156 large tar timeout

### DIFF
--- a/step_function/lambda.tf
+++ b/step_function/lambda.tf
@@ -72,7 +72,8 @@ resource "aws_lambda_function" "editorial_integration" {
   package_type = "Image"
   function_name = "${var.env}-${var.prefix}-editorial-integration"
   role = aws_iam_role.retrieve_bagit_lambda_role.arn
-  timeout = 30
+  memory_size = 512
+  timeout = 900
   environment {
     variables = {
       "TE_VERSION_JSON" = jsonencode({"int-${var.prefix}-version": "0.0.0", "text-parser-version": "v0.0", "lambda-functions-version": [ { "int-${var.prefix}-bagit-checksum-validation": "0.0.0" }, { "int-${var.prefix}-files-checksum-validation": "0.0.0" }, { "int-text-parser-version": "v0.0" } ]})

--- a/step_function/templates/step-function-definition.json.tftpl
+++ b/step_function/templates/step-function-definition.json.tftpl
@@ -294,16 +294,6 @@
       "Type": "Task",
       "Resource": "${editorial_integration_lambda}",
       "Next": "Editorial SNS Publish",
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "States.TaskFailed"
-          ],
-          "BackoffRate": 1,
-          "IntervalSeconds": 1,
-          "MaxAttempts": 1
-        }
-      ],
       "Catch": [
         {
           "ErrorEquals": [

--- a/step_function/templates/step-function-definition.json.tftpl
+++ b/step_function/templates/step-function-definition.json.tftpl
@@ -301,7 +301,7 @@
           ],
           "BackoffRate": 1,
           "IntervalSeconds": 1,
-          "MaxAttempts": 3
+          "MaxAttempts": 1
         }
       ],
       "Catch": [


### PR DESCRIPTION
Proposed fix for timeout issue that may occur when generating larger tar files in the `EditorialIntegration` step of `${env}-tre-state-machine` :

* Increase Lambda's max memory from 128MB to 512MB; this appears to reduce run time from over ~30 seconds to ~11 seconds
* Increase step's timeout from 30 seconds to 900 seconds (15 minutes, which happens to be the maximum permitted)
* Remove step's automatic retry attempts as retries for this step won't work with the current implementation

Further information can be found in tickets DTE-156 anD DTE-157.