### PR TITLE
Persist DTE-174 parser timeout fix in dev env

### DIFF
--- a/step_function/lambda.tf
+++ b/step_function/lambda.tf
@@ -59,8 +59,8 @@ resource "aws_lambda_function" "judgment_parser_lambda" {
   package_type = "Image"
   function_name = "${var.env}-${var.prefix}-run-judgment-parser"
   role = aws_iam_role.retrieve_bagit_lambda_role.arn
-  memory_size = 512
-  timeout = 600
+  memory_size = 1536
+  timeout = 900
 
   tags = {
     ApplicationType = ".NET"


### PR DESCRIPTION
I believe these are the changes applied manually to fix the parser timeout issue reported in DTE-174.

This PR persists them in the IaC config so they're not lost.