### PR TITLE
DTE-191: Add Step Function version info to metadata (dev)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ backend-*.conf
 
 go.sum
 /tmp/
+/.idea/
+/*.iml

--- a/step_function/lambda.tf
+++ b/step_function/lambda.tf
@@ -76,8 +76,20 @@ resource "aws_lambda_function" "editorial_integration" {
   timeout = 900
   environment {
     variables = {
-      "TE_VERSION_JSON" = jsonencode({"int-${var.prefix}-version": "0.0.0", "text-parser-version": "v0.0", "lambda-functions-version": [ { "int-${var.prefix}-bagit-checksum-validation": "0.0.0" }, { "int-${var.prefix}-files-checksum-validation": "0.0.0" }, { "int-text-parser-version": "v0.0" } ]})
-      "TE_PRESIGNED_URL_EXPIRY" = 60
+      "TRE_VERSION_JSON" = jsonencode(
+        {
+          "${var.env}-${var.prefix}-version": "${var.image_versions.tre_step_function_version}",
+          "lambda-functions-version": [
+            {"${var.env}-${var.prefix}-bagit-checksum-validation": "${var.image_versions.tre_bagit_checksum_validation}"},
+            {"${var.env}-${var.prefix}-files-checksum-validation": "${var.image_versions.tre_files_checksum_validation}"},
+            {"${var.env}-${var.prefix}-prepare-parser-input": "${var.image_versions.tre_prepare_parser_input}"},
+            {"${var.env}-${var.prefix}-editorial-integration": "${var.image_versions.tre_editorial_integration}"},
+            {"${var.env}-${var.prefix}-run-judgments-parser": "${var.image_versions.tre_run_judgment_parser}"},
+            {"${var.env}-${var.prefix}-slack-alerts": "${var.image_versions.tre_slack_alerts}"}
+          ]
+        }
+      )
+      "TRE_PRESIGNED_URL_EXPIRY" = 60
       "S3_BUCKET" = aws_s3_bucket.editorial_judgment_out.bucket
       "S3_OBJECT_ROOT" = "parsed/"
       "S3_FILE_PARSER_META"="te-meta.json"

--- a/step_function/lambda.tf
+++ b/step_function/lambda.tf
@@ -76,9 +76,10 @@ resource "aws_lambda_function" "editorial_integration" {
   timeout = 900
   environment {
     variables = {
+      "TRE_ENV" = "${var.env}"
+      "TRE_VERSION" = "${var.tre_version}"
       "TRE_VERSION_JSON" = jsonencode(
         {
-          "${var.env}-${var.prefix}-version": "${var.image_versions.tre_step_function_version}",
           "lambda-functions-version": [
             {"${var.env}-${var.prefix}-bagit-checksum-validation": "${var.image_versions.tre_bagit_checksum_validation}"},
             {"${var.env}-${var.prefix}-files-checksum-validation": "${var.image_versions.tre_files_checksum_validation}"},

--- a/step_function/variables.tf
+++ b/step_function/variables.tf
@@ -38,10 +38,13 @@ variable "editorial_sns_sub_arn" {
   type = string
 }
 
-
-
 variable "account_id" {
   description = "Account ID where Image for the Lambda function will be"
+  type = string
+}
+
+variable "tre_version" {
+  description = "TRE Step Function version (update if Step Function flow or called Lambda function versions change)"
   type = string
 }
 


### PR DESCRIPTION
PR to implement changes to inject TRE component versions into the JSON file sent in the editorial payload (`TRE-${CONSIGNMENT_REF}-metadata.json`) in the `dev` environment. Additional groups of PRs will be required to update the other environments.

This PR is one of 3 related PRs in different repositories and must be merged second; i.e. the merge order must be:

1. DTE-191 PR in repo `da-transform-judgments-pipeline`
2. DTE-191 PR in repo `da-transform-terraform-modules` (this one)
3. DTE-191 PR in repo `da-transform-terraform-environments`