### PR TITLE
Feature/dte 231/standardise lambdas -> dev

### DIFF
--- a/step_functions/receive_and_process_bag/lambda.tf
+++ b/step_functions/receive_and_process_bag/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "rapb_bagit_checksum_validation" {
-  image_uri     = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda_functions/te-bagit-checksum-validation:${var.rapb_image_versions.tre_bagit_checksum_validation}"
+  image_uri     = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda_functions/tre-bagit-checksum-validation:${var.rapb_image_versions.tre_bagit_checksum_validation}"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-rapb-bagit-checksum-validation"
   role          = aws_iam_role.receive_and_process_bag_lambda_invoke_role.arn
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "rapb_bagit_checksum_validation" {
 }
 
 resource "aws_lambda_function" "rapb_files_checksum_validation" {
-  image_uri     = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda_functions/te-files-checksum-validation:${var.rapb_image_versions.tre_files_checksum_validation}"
+  image_uri     = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/lambda_functions/tre-files-checksum-validation:${var.rapb_image_versions.tre_files_checksum_validation}"
   package_type  = "Image"
   function_name = "${var.env}-${var.prefix}-rapb-files-checksum-validation"
   role          = aws_iam_role.receive_and_process_bag_lambda_invoke_role.arn


### PR DESCRIPTION
Change to adopt standardised lambda naming update (te_ prefix changed to tre_); before merge and subsequent trigger of pipeline it is required that:

* The following Docker images are built and pushed to ECR:
  * tre-bagit-checksum-validation
  * tre-files-checksum-validation
* The correct versions are set for the above images in the respective ${env}-tfvars Parameter Store record