### PR TITLE
TDR-3694: remove permissions so that activity in V1 can not be triggered

### DIFF
--- a/sqs/iam.tf
+++ b/sqs/iam.tf
@@ -32,37 +32,3 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 }
 
 
-# SQS Queue policy document
-
-data "aws_iam_policy_document" "tdr_sqs_policy" {
-  statement {
-    actions = ["sqs:SendMessage"]
-    effect  = "Allow"
-    principals {
-      type = "AWS"
-      identifiers = [
-        var.tdr_role_arn
-      ]
-    }
-    resources = [
-      aws_sqs_queue.tdr_message_queue.arn
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "editorial_sqs_policy" {
-  statement {
-    actions = ["sqs:SendMessage"]
-    effect  = "Allow"
-    principals {
-      type = "AWS"
-      identifiers = [
-        var.editorial_role_arn
-      ]
-    }
-    resources = [
-      aws_sqs_queue.editorial_message_queue.arn
-    ]
-  }
-}
-

--- a/sqs/sqs_queue.tf
+++ b/sqs/sqs_queue.tf
@@ -7,11 +7,6 @@ resource "aws_sqs_queue" "tdr_message_queue" {
   sqs_managed_sse_enabled = true
 }
 
-resource "aws_sqs_queue_policy" "name" {
-  queue_url = aws_sqs_queue.tdr_message_queue.id
-  policy    = data.aws_iam_policy_document.tdr_sqs_policy.json
-}
-
 resource "aws_sqs_queue" "tdr_message_deadletter_queue" {
   name                    = "${var.env}-${var.prefix}-tdr-in-deadletter-queue"
   sqs_managed_sse_enabled = true
@@ -24,11 +19,6 @@ resource "aws_sqs_queue" "editorial_message_queue" {
     maxReceiveCount     = 5
   })
   sqs_managed_sse_enabled = true
-}
-
-resource "aws_sqs_queue_policy" "editorial_message_queue_policy" {
-  queue_url = aws_sqs_queue.editorial_message_queue.id
-  policy    = data.aws_iam_policy_document.editorial_sqs_policy.json
 }
 
 resource "aws_sqs_queue" "editorial_retry_deadletter_queue" {


### PR DESCRIPTION
Merging to `test` branch, which will be pulled in when run test codepipeline with a merge to `test` branch in `environments`. 

The change will remove permissions for input to v1 sqs entry points such that:
- tdr can't publish to `tdr-in`
- fcl can't publish to `editorial-retry`

Have checked logs to ensure these are not publishing to these sqs since shut down of V1... so this just ensures couldn't in future.